### PR TITLE
Context no longer populated

### DIFF
--- a/index.js
+++ b/index.js
@@ -168,7 +168,7 @@ GDSwitch.prototype.getServices = function() {
     .setCharacteristic(Characteristic.Manufacturer, 'GDSwitches')
     .setCharacteristic(Characteristic.Model, '001')
     .setCharacteristic(Characteristic.SerialNumber, 'GDS-001')
-    .setCharacteristic(Characteristic.FirmwareRevision, '0.0.3')
+    .setCharacteristic(Characteristic.FirmwareRevision, '1.0.0')
 
   let garageDoorService = new Service.GarageDoorOpener(this.name)
 

--- a/index.js
+++ b/index.js
@@ -35,7 +35,7 @@ function GDSwitch(log, config) {
   createServer(accessory)
 }
 
-GDSwitch.prototype.setTargetState = function(targetState, callback, context) {
+GDSwitch.prototype.setTargetState = function(targetState, callback, context, extraDetails) {
   const accessory = this
   const currentState = accessory.garageDoorService.getCharacteristic(Characteristic.CurrentDoorState).value
 
@@ -46,10 +46,11 @@ GDSwitch.prototype.setTargetState = function(targetState, callback, context) {
 
   if (accessory.debug) accessory.log(`Transitioning to ${targetState}`)
 
-  if (!context) {
+  if (!context && !extraDetails) {
     // If there's no context the command has come from inside the class
     // Don't run the command to update state, just set it
     // This allows us to set the value from an external source, not from within the Home app
+    if (accessory.debug) accessory.log('No context set, ignoring command')
     callback(null)
     return
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-garage-door-switch",
-  "version": "0.0.4",
+  "version": "1.0.0",
   "description": "Homebridge plugin to control a garagedoor using scripts",
   "homepage": "https://github.com/ezzizzle/homebridge-garage-door-switch",
   "bugs": {


### PR DESCRIPTION
The context object is no longer populated when calling `setTargetState`. I was using this to determine when the method was being called externally as opposed to internally (within the package). There is another argument that still appears to be set which I have transitioned to using. Hopefully this is backwards compatible. 🤞 

This may fix #3 as well.